### PR TITLE
fix: ESlint conflict with swiperjs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
   "rules": {
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "prettier/prettier": "error",
-    "react/prop-types": 0 // Отключаем правило проверки передаваемых типов.
+    "react/prop-types": 0, // Отключаем правило проверки передаваемых типов.
+    "import/no-unresolved": [2, { "ignore": ["swiper/react", "swiper/css"] }]
   }
 }


### PR DESCRIPTION
ESLint конфликтует со способом подключения плагина swiper.
**Вот обсуждения:**
https://github.com/nolimits4web/swiper/issues/5058
https://github.com/import-js/eslint-plugin-import/issues/2266
https://github.com/eslint/eslint/issues/15171
**Решение** - отключить работу модуля `import/no-unresolved` для `["swiper/react", "swiper/css"]`.
