### PR TITLE
refact: delete not needed components for swiper in mobile screen reso…

### DIFF
--- a/src/components/Publication/styles.jsx
+++ b/src/components/Publication/styles.jsx
@@ -11,7 +11,7 @@ export const ImageContainer = styled.div`
   transition: all 0.3s ease-in-out;
   overflow: hidden;
 
-  @media (max-width: 1280px) {
+  @media (max-width: 1230px) {
     width: 291px;
     height: 158px;
   }
@@ -41,7 +41,7 @@ export const Links = styled.div`
   bottom: -70px;
   transition: all 0.3s ease-in-out;
 
-  @media (max-width: 1280px) {
+  @media (max-width: 1230px) {
     height: 60px;
     padding-top: 15px;
     padding-bottom: 15px;
@@ -68,24 +68,32 @@ export const Container = styled.div`
   position: relative;
   overflow: hidden;
 
-  @media (max-width: 1280px) {
-    width: 330px;
-    height: 515px;
-    margin-bottom: 42px;
-  }
-
-  @media (max-width: 480px) {
-    width: 288px;
-    height: 462px;
-    margin-bottom: 20px;
-  }
-
   &:hover ${ImageContainer} {
     height: 158px;
   }
 
   &:hover ${Links} {
     bottom: 0;
+  }
+
+  @media (max-width: 1230px) {
+    width: 330px;
+    height: 515px;
+    margin-bottom: 42px;
+
+    &:hover ${Links} {
+      bottom: unset;
+    }
+  }
+
+  @media (max-width: 480px) {
+    width: 288px;
+    height: 462px;
+    margin-bottom: 55px;
+
+    &:hover ${ImageContainer} {
+      height: 160px;
+    }
   }
 `;
 
@@ -102,7 +110,7 @@ export const Information = styled.div`
   min-height: 305px;
   box-sizing: border-box;
 
-  @media (max-width: 1280px) {
+  @media (max-width: 1230px) {
     padding-bottom: 10px;
     height: 277px;
     min-height: unset;
@@ -143,7 +151,7 @@ export const Authors = styled.p`
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 
-  @media (max-width: 1280px) {
+  @media (max-width: 1230px) {
     margin-bottom: 12px;
   }
 

--- a/src/components/Publications/index.jsx
+++ b/src/components/Publications/index.jsx
@@ -1,24 +1,18 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+/* eslint-disable react/jsx-curly-brace-presence */
+import { useCallback, useRef } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Pagination } from 'swiper';
 import 'swiper/css';
 import 'swiper/css/pagination';
-import {
-  Section,
-  Container,
-  Title,
-  ScrollContainer,
-  ScrollList,
-} from './styles';
+import { Section, Container, Title } from './styles';
 import store from '../../store/store';
 import SwipeButton from '../Ui/SwipeButton';
 import HideSwiperButton from '../HideSwiperButton';
 import Publication from '../Publication';
+import './styles.css';
 
 const Publications = () => {
   const { data } = store.publications;
-
-  const [swiperEnabled, setSwiperEnabled] = useState(true);
 
   const prevButtonRef = useRef(null);
   const nextButtonRef = useRef(null);
@@ -31,20 +25,12 @@ const Publications = () => {
     nextButtonRef.current.click();
   }, [nextButtonRef]);
 
-  useEffect(() => {
-    const screenWidth = document.documentElement.clientWidth;
-
-    if (screenWidth < 1280) setSwiperEnabled(false);
-  }, []);
-
   return (
     <Section>
       <Container>
         <Title>Публикации</Title>
-
-        {swiperEnabled > 0 ? (
+        {
           <>
-            {/* Desktop version with swiperjs */}
             <SwipeButton
               design="light"
               direction="prev"
@@ -56,10 +42,22 @@ const Publications = () => {
               onClick={handleNextClick}
             />
             <Swiper
-              spaceBetween={30}
-              slidesPerView={3}
-              pagination
+              pagination={{
+                clickable: true,
+              }}
+              breakpoints={{
+                768: {
+                  centeredSlides: false,
+                  spaceBetween: 30,
+                },
+                320: {
+                  centeredSlides: true,
+                  spaceBetween: 8,
+                  slidesPerView: 'auto',
+                },
+              }}
               modules={[Pagination]}
+              className="mySwiper"
             >
               <HideSwiperButton direction="prev" refProp={prevButtonRef} />
               <HideSwiperButton direction="next" refProp={nextButtonRef} />
@@ -72,16 +70,7 @@ const Publications = () => {
               })}
             </Swiper>
           </>
-        ) : (
-          <ScrollContainer>
-            {/* Tablet and mobile version without swiperjs */}
-            <ScrollList>
-              {data.map((publication) => {
-                return <Publication data={publication} key={publication.uid} />;
-              })}
-            </ScrollList>
-          </ScrollContainer>
-        )}
+        }
       </Container>
     </Section>
   );

--- a/src/components/Publications/styles.css
+++ b/src/components/Publications/styles.css
@@ -1,0 +1,15 @@
+.swiper-slide {
+  max-width: 348px;
+}
+
+@media (max-width: 1230px) {
+  .swiper-slide {
+    max-width: 330px;
+  }
+}
+
+@media (max-width: 480px) {
+  .swiper-slide {
+    max-width: 288px;
+  }
+}

--- a/src/components/Publications/styles.jsx
+++ b/src/components/Publications/styles.jsx
@@ -6,7 +6,7 @@ export const Section = styled.section`
   }};
   padding: 80px 0 370px;
 
-  @media (max-width: 1280px) {
+  @media (max-width: 1230px) {
     padding-top: 60px;
     padding-bottom: 290px;
   }
@@ -34,7 +34,7 @@ export const Title = styled.h2`
   margin: 0 0 30px;
   text-align: center;
 
-  @media (max-width: 1280px) {
+  @media (max-width: 1230px) {
     font: var(--header-24);
     margin-bottom: 40px;
   }
@@ -42,22 +42,5 @@ export const Title = styled.h2`
   @media (max-width: 480px) {
     font: var(--header-16);
     margin-bottom: 20px;
-  }
-`;
-
-export const ScrollContainer = styled.div`
-  overflow-x: auto;
-  overflow-y: hidden;
-`;
-
-export const ScrollList = styled.ul`
-  list-style: none;
-  margin: 0;
-  display: inline-grid;
-  column-gap: 30px;
-  grid-auto-flow: column;
-
-  @media (max-width: 480px) {
-    column-gap: 8px;
   }
 `;


### PR DESCRIPTION
Я убрал отключение swiperjs на планшете и мобильном разрешении.
Я смог настроить работу swiperjs в соответствии с макетом на таких разрешениях. 
Ну не столько смог, сколько подсказали. )))
Но одну проблему я победить не могу. 
Чтобы корректно работал swiperjs, мне надо подключать файл styles.css в компоненте Publications, чтобы ограничить ширину для объекта с классом swiper-slide (это встроенный в swiperjs компонент SwiperSlide). Без такой стилизации SwiperSlide занимает всю доступную ширину в 100%.
Если у вас есть идеи, как это можно делать через styled-components, то скажите. Я не смог решить найти какое-то решение проблемы через styled-components.
